### PR TITLE
Fix/new host selection

### DIFF
--- a/src/main/java/com/revature/game_logic/blackjack/BlackjackGame.java
+++ b/src/main/java/com/revature/game_logic/blackjack/BlackjackGame.java
@@ -140,7 +140,10 @@ public class BlackjackGame extends BaseGame<BlackjackPlayer> {
         if(activePlayers.remove(player)) {
             onPlayerEndsTurn(); //A player leaving counts as ending their turn.
         }
-        chooseNewHost();
+        if(Objects.equals(hostPlayer.getPlayerId(), playerId)){
+            hostPlayer = null;
+            chooseNewHost();
+        }
     }
 
     public void onPlayerHit(String playerId){

--- a/src/main/java/com/revature/game_logic/common/BaseGame.java
+++ b/src/main/java/com/revature/game_logic/common/BaseGame.java
@@ -84,6 +84,7 @@ public abstract class BaseGame<T extends BasePlayer<?>> {
         }
         if (markedForDrop != null) {
             waitingPlayers.remove();
+            updateWaitingPlayers();
         }
     }
 


### PR DESCRIPTION
fixed two issues that were caused when a player leaves the game:
 - when the host leaves a blackjack game, a new host is selected
 - when a player leaves any game and was waiting for the game to start, other waiting players are notified of their new queue positions via the websocket.